### PR TITLE
Preserve deployment success through cleanup traps

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -533,6 +533,9 @@ jobs:
 
             DEPLOY_OK=0
             cleanup_staging() {
+              local exit_code=$?
+              trap - EXIT
+              set +e
               sudo rm -rf "$STAGING" 2>/dev/null || true
               if [ -n "$DOCKER_CONFIG_DIR" ]; then
                 sudo rm -rf "$DOCKER_CONFIG_DIR" 2>/dev/null || true
@@ -547,6 +550,7 @@ jobs:
                 sudo rm -f "$TARBALL" 2>/dev/null || true
                 sudo rm -f "$DEPLOY_KIT" 2>/dev/null || true
               fi
+              exit "$exit_code"
             }
             trap cleanup_staging EXIT
 
@@ -699,6 +703,7 @@ jobs:
 
             DEPLOY_OK=1
             echo "Staging deployment completed on ${{ matrix.server.name }}"
+            exit 0
 
       - name: Verify staging deployment (${{ matrix.server.name }})
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -683,6 +683,9 @@ jobs:
             # naturally via tmp cleanup or be overwritten on retry.)
             DEPLOY_OK=0
             cleanup_staging() {
+              local exit_code=$?
+              trap - EXIT
+              set +e
               sudo rm -rf "$STAGING" 2>/dev/null || true
               if [ -n "$DOCKER_CONFIG_DIR" ]; then
                 sudo rm -rf "$DOCKER_CONFIG_DIR" 2>/dev/null || true
@@ -697,6 +700,7 @@ jobs:
                 sudo rm -f "$TARBALL" 2>/dev/null || true
                 sudo rm -f "$DEPLOY_KIT" 2>/dev/null || true
               fi
+              exit "$exit_code"
             }
             trap cleanup_staging EXIT
 
@@ -885,6 +889,7 @@ jobs:
             DEPLOY_OK=1
             echo ""
             echo "✅ ${{ matrix.server.name }}: Deployment completed!"
+            exit 0
 
       - name: Verify Deployment (${{ matrix.server.name }})
         if: success()

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -174,10 +174,14 @@ jobs:
 
             DOCKER_CONFIG_DIR=""
             cleanup() {
+              local exit_code=$?
+              trap - EXIT
+              set +e
               sudo rm -rf "$STAGING" 2>/dev/null || true
               if [ -n "$DOCKER_CONFIG_DIR" ]; then
                 sudo rm -rf "$DOCKER_CONFIG_DIR" 2>/dev/null || true
               fi
+              exit "$exit_code"
             }
             trap cleanup EXIT
 
@@ -225,6 +229,7 @@ jobs:
               fi
               exit "$rollback_status"
             fi
+            exit 0
 
       - name: Verify rollback on ${{ matrix.server.name }}
         uses: appleboy/ssh-action@v1.2.0

--- a/portfolio/scripts/deploy.sh
+++ b/portfolio/scripts/deploy.sh
@@ -473,6 +473,8 @@ parse_arguments() {
 
 cleanup() {
     local exit_code=$?
+    trap - EXIT
+    set +e
 
     if [[ ${exit_code} -ne 0 ]]; then
         log_separator
@@ -489,6 +491,8 @@ cleanup() {
         local dur=$(( $(date +%s) - DEPLOYMENT_START_TIME ))
         log INFO "Total time: $((dur / 60))m $((dur % 60))s"
     fi
+
+    exit "${exit_code}"
 }
 
 # Artifact-mode rollback: undo mutations in reverse order


### PR DESCRIPTION
staging run 29154467020 deployed staging-2 with 5/5 health checks but SSH wrapper returned status 1 after cleanup; fix preserves original exit code in staging/production/rollback/deploy.sh; validation Bash harness success=0/failure=42, YAML, lint/typecheck, 10 tests. Link run.