### PR TITLE
Fix image release identity for deployment retries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1065,15 +1065,15 @@ jobs:
             fi
             echo "Verified $ASSET_COUNT local nginx static assets for $SVC_NAME"
 
-            # Verify current release matches the deployed SHA
+            # Log the directory identity; deploy metadata below is authoritative
+            # for the source Git SHA because image release IDs include a digest.
             sudo test -L "$DEPLOY_ROOT/current" || fail "missing current symlink: $DEPLOY_ROOT/current"
-            CURRENT_SHA=$(basename "$(sudo readlink -f "$DEPLOY_ROOT/current")")
-            if [ "$CURRENT_SHA" = "${{ github.sha }}" ]; then
-              echo "current -> ${CURRENT_SHA:0:12} (matches deployed SHA)"
-            else
-              echo "current -> ${CURRENT_SHA} but deployed SHA is ${{ github.sha }}"
-              exit 1
-            fi
+            CURRENT_RELEASE_ID=$(basename "$(sudo readlink -f "$DEPLOY_ROOT/current")")
+            echo "current -> $CURRENT_RELEASE_ID"
+            case "$CURRENT_RELEASE_ID" in
+              "${{ github.sha }}"|"${{ github.sha }}-"*) ;;
+              *) echo "Warning: current release ID does not begin with workflow SHA ${{ github.sha }}" ;;
+            esac
             RELEASE_COUNT=$(sudo find "$DEPLOY_ROOT/releases" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
             echo "Releases on disk: $RELEASE_COUNT"
 

--- a/portfolio/lib/__tests__/deploymentReleaseIdentity.contract.test.ts
+++ b/portfolio/lib/__tests__/deploymentReleaseIdentity.contract.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const deployScript = fs.readFileSync(path.join(process.cwd(), 'scripts', 'deploy.sh'), 'utf8');
+const productionWorkflow = fs.readFileSync(
+  path.join(process.cwd(), '..', '.github', 'workflows', 'deploy.yml'),
+  'utf8',
+);
+
+function functionBody(name: string): string {
+  const match = deployScript.match(
+    new RegExp(`\\n${name}\\(\\) \\{([^]*?)\\r?\\n\\}\\r?\\n\\r?\\n(?=[a-z_]+\\(\\))`, 'm'),
+  );
+  expect(match, `${name} should exist`).not.toBeNull();
+  return match?.[1] ?? '';
+}
+
+describe('deployment release directory identity', () => {
+  it('qualifies image releases with the first 12 lowercase digest characters', () => {
+    expect(deployScript).toContain('[[ "${DOCKER_IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]');
+    expect(functionBody('image_release_id')).toContain(
+      `printf '%s-%s\\n' "\${RELEASE_SHA}" "\${digest:0:12}"`,
+    );
+    expect(functionBody('stage_image_release')).toContain(
+      'local target="${DEPLOY_RELEASES_DIR}/${release_id}"',
+    );
+    expect(functionBody('stage_image_release')).toContain('RELEASE_ID="${release_id}"');
+  });
+
+  it('keeps release directory identity separate from the source SHA', () => {
+    expect(deployScript).toContain('RELEASE_ID=""');
+    expect(deployScript).toContain('RELEASE_SHA=""');
+    expect(functionBody('stage_release')).toContain('RELEASE_ID="${RELEASE_SHA}"');
+    expect(functionBody('stage_release')).toContain(
+      'local target="${DEPLOY_RELEASES_DIR}/${RELEASE_ID}"',
+    );
+
+    const atomicSwap = functionBody('atomic_symlink_swap');
+    expect(atomicSwap).toContain('if [[ -z "${RELEASE_ID}" ]]');
+    expect(atomicSwap).toContain('local target="${DEPLOY_RELEASES_DIR}/${RELEASE_ID}"');
+    expect(atomicSwap).not.toContain('image_release_id');
+    expect(atomicSwap).not.toContain('MODE');
+  });
+
+  it('reuses the same image digest without replacing its directory', () => {
+    const stageImageRelease = functionBody('stage_image_release');
+    const reuseReturn = stageImageRelease.indexOf('return 0');
+
+    expect(stageImageRelease).toContain('docker pull "${DOCKER_IMAGE}"');
+    expect(stageImageRelease).toContain('verify_pulled_image_architecture');
+    expect(stageImageRelease).toContain('if [[ "${staged_image}" == "${DOCKER_IMAGE}" ]]');
+    expect(stageImageRelease).toContain('RELEASE_DIR="${target}"');
+    expect(stageImageRelease).toContain('reusing existing static files');
+    expect(stageImageRelease.indexOf('docker pull "${DOCKER_IMAGE}"')).toBeLessThan(reuseReturn);
+    expect(stageImageRelease.indexOf('verify_pulled_image_architecture')).toBeLessThan(reuseReturn);
+    expect(stageImageRelease.indexOf('NEW_RELEASE_DIR="${target}"')).toBeGreaterThan(reuseReturn);
+    expect(stageImageRelease).not.toContain('rm -rf "${target}"');
+  });
+
+  it('stages a different digest for the same SHA as a distinct immutable directory', () => {
+    const stageImageRelease = functionBody('stage_image_release');
+
+    expect(stageImageRelease).not.toContain('different image digest');
+    expect(stageImageRelease).not.toContain('deploy a new SHA');
+    expect(stageImageRelease).toContain('mv "${staging}" "${target}"');
+    expect(stageImageRelease).toContain('NEW_RELEASE_DIR="${target}"');
+  });
+
+  it('tracks and removes only a newly materialized failed release after restoration', () => {
+    const stageRelease = functionBody('stage_release');
+    const rollbackArtifact = functionBody('rollback_artifact');
+
+    expect(deployScript).toContain('NEW_RELEASE_DIR=""');
+    expect(stageRelease.indexOf('NEW_RELEASE_DIR="${target}"')).toBeGreaterThan(
+      stageRelease.indexOf('mv "${staging}" "${target}"'),
+    );
+    expect(stageRelease.indexOf('NEW_RELEASE_DIR="${target}"')).toBeGreaterThan(
+      stageRelease.indexOf('return 0'),
+    );
+    expect(rollbackArtifact).toContain('current_target=$(readlink -f "${DEPLOY_CURRENT_LINK}"');
+    expect(rollbackArtifact).toContain('new_release_target=$(readlink -f "${NEW_RELEASE_DIR}"');
+    expect(rollbackArtifact).toContain('[[ "${current_target}" != "${new_release_target}" ]]');
+    expect(rollbackArtifact).toContain('rm -rf "${NEW_RELEASE_DIR}"');
+    expect(rollbackArtifact.indexOf('rm -rf "${NEW_RELEASE_DIR}"')).toBeGreaterThan(
+      rollbackArtifact.indexOf('Restoring nginx config'),
+    );
+  });
+
+  it('rolls back by directory ID while restoring the source SHA from metadata', () => {
+    const rollbackDeploy = functionBody('rollback_deploy');
+
+    expect(rollbackDeploy).toContain('RELEASE_ID="${target_release_id}"');
+    expect(rollbackDeploy).toContain('RELEASE_DIR="${DEPLOY_RELEASES_DIR}/${RELEASE_ID}"');
+    expect(rollbackDeploy).toContain('RELEASE_SHA="$(release_meta_value "${RELEASE_DIR}" sha)"');
+    expect(rollbackDeploy).toContain('if [[ -z "${RELEASE_SHA}" ]]');
+    expect(rollbackDeploy.indexOf('RELEASE_SHA="$(release_meta_value')).toBeLessThan(
+      rollbackDeploy.indexOf('prepare_docker_systemd_unit'),
+    );
+    expect(rollbackDeploy).not.toContain('NEW_RELEASE_DIR=');
+  });
+
+  it('rejects ambiguous rollback SHA-prefix matches instead of guessing', () => {
+    const resolveRollbackRelease = functionBody('resolve_rollback_release');
+
+    expect(deployScript).toContain('^[0-9a-fA-F]{7,40}$');
+    expect(resolveRollbackRelease).toContain('-name "${ROLLBACK_TARGET_SHA}*"');
+    expect(resolveRollbackRelease).toContain('if [[ ${#matches[@]} -gt 1 ]]');
+    expect(resolveRollbackRelease).toContain(
+      'Rollback target ${ROLLBACK_TARGET_SHA} is ambiguous: ${matches[*]}',
+    );
+  });
+
+  it('verifies production source SHA from metadata and accepts digest-qualified IDs', () => {
+    expect(productionWorkflow).toContain(
+      'CURRENT_RELEASE_ID=$(basename "$(sudo readlink -f "$DEPLOY_ROOT/current")")',
+    );
+    expect(productionWorkflow).toContain('echo "current -> $CURRENT_RELEASE_ID"');
+    expect(productionWorkflow).toContain('"${{ github.sha }}"|"${{ github.sha }}-"*)');
+    expect(productionWorkflow).toContain('META_FILE="$DEPLOY_ROOT/current/.deploy/meta.json"');
+    expect(productionWorkflow).toContain(
+      "sudo grep -q '\"sha\": \"${{ github.sha }}\"' \"$META_FILE\"",
+    );
+    expect(productionWorkflow).not.toContain('if [ "$CURRENT_SHA" = "${{ github.sha }}" ]');
+  });
+});

--- a/portfolio/scripts/deploy.sh
+++ b/portfolio/scripts/deploy.sh
@@ -44,7 +44,7 @@
 #                --skip-build        [legacy]   Skip npm ci + next build
 #                --skip-nginx        Skip nginx config update
 #                --rollback          Roll back to the newest previous release
-#                --rollback-to SHA   Roll back to a specific retained release
+#                --rollback-to SHA   Roll back by retained source Git SHA prefix
 #                --force             [legacy]   Deploy with uncommitted changes
 #                --help              Show help
 #
@@ -271,7 +271,9 @@ readonly NC='\033[0m'
 
 MODE="legacy"              # "artifact" | "image" | "legacy"
 RELEASE_DIR=""             # set in image/artifact mode
+RELEASE_ID=""              # release directory basename in image/artifact/rollback mode
 RELEASE_SHA=""             # set in image/artifact mode
+NEW_RELEASE_DIR=""         # final release directory materialized by this deploy
 DOCKER_IMAGE=""             # set in image mode
 DOCKER_HOST_ARCH=""         # normalized Docker daemon architecture in image mode
 ROLLBACK_TARGET_SHA=""      # set in rollback mode when a specific target is requested
@@ -363,9 +365,10 @@ CONFIGURATION
   Site config:    /etc/deploy/sites/<name>.conf
 
 LAYOUT (image/artifact mode)
-  /opt/<service>/config/.env.local       — secrets, survives deploys
-  /opt/<service>/releases/<sha>/         — one dir per release, auto-trimmed
-  /opt/<service>/current -> releases/X   — atomic symlink flipped at deploy time
+    /opt/<service>/config/.env.local        — secrets, survives deploys
+    /opt/<service>/releases/<sha>/          — artifact release, auto-trimmed
+    /opt/<service>/releases/<sha>-<digest>/ — image release; digest is 12 hex chars
+    /opt/<service>/current -> releases/X    — atomic symlink flipped at deploy time
 EOF
     exit 0
 }
@@ -402,8 +405,8 @@ parse_arguments() {
                     log ERROR "--image requires an image reference"
                     exit 1
                 fi
-                if [[ "${DOCKER_IMAGE}" != *@sha256:* ]]; then
-                    log ERROR "--image must be an immutable digest ref (expected repo@sha256:..., got: ${DOCKER_IMAGE})"
+                if ! [[ "${DOCKER_IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]; then
+                    log ERROR "--image must end with an immutable lowercase digest (expected repo@sha256:<64 lowercase hex>, got: ${DOCKER_IMAGE})"
                     exit 1
                 fi
                 shift 2
@@ -549,6 +552,21 @@ rollback_artifact() {
             log SUCCESS "nginx rolled back"
         else
             log ERROR "CRITICAL: nginx rollback failed — manual intervention required"
+        fi
+    fi
+
+    # Remove only a final release directory created by this failed deploy, and
+    # only after restoration confirms it is no longer active.
+    if [[ -n "${NEW_RELEASE_DIR}" ]] && [[ -d "${NEW_RELEASE_DIR}" ]]; then
+        local current_target=""
+        local new_release_target=""
+        current_target=$(readlink -f "${DEPLOY_CURRENT_LINK}" 2>/dev/null || true)
+        new_release_target=$(readlink -f "${NEW_RELEASE_DIR}" 2>/dev/null || true)
+        if [[ -n "${new_release_target}" ]] && [[ "${current_target}" != "${new_release_target}" ]]; then
+            log INFO "Removing failed staged release: ${NEW_RELEASE_DIR}"
+            rm -rf "${NEW_RELEASE_DIR}"
+        else
+            log WARN "Keeping failed staged release because it is still active: ${NEW_RELEASE_DIR}"
         fi
     fi
 
@@ -1252,9 +1270,10 @@ record_previous_release() {
 }
 
 stage_release() {
+    RELEASE_ID="${RELEASE_SHA}"
     log STEP "Staging release ${RELEASE_SHA}..."
 
-    local target="${DEPLOY_RELEASES_DIR}/${RELEASE_SHA}"
+    local target="${DEPLOY_RELEASES_DIR}/${RELEASE_ID}"
     local current_target=""
     local target_real=""
 
@@ -1302,52 +1321,51 @@ stage_release() {
 
     rm -rf "${target}"
     mv "${staging}" "${target}"
+    NEW_RELEASE_DIR="${target}"
 
     local file_count
     file_count=$(find "${target}" -type f | wc -l)
     log SUCCESS "Staged ${file_count} files to ${target}"
 }
 
+image_release_id() {
+    local digest="${DOCKER_IMAGE##*@sha256:}"
+    printf '%s-%s\n' "${RELEASE_SHA}" "${digest:0:12}"
+}
+
 stage_image_release() {
-    log STEP "Staging image release ${RELEASE_SHA}..."
+    local release_id
+    release_id="$(image_release_id)"
+    RELEASE_ID="${release_id}"
+    log STEP "Staging image release ${release_id}..."
 
-    local target="${DEPLOY_RELEASES_DIR}/${RELEASE_SHA}"
-    local staging="${DEPLOY_RELEASES_DIR}/.${RELEASE_SHA}.staging.$$"
+    local target="${DEPLOY_RELEASES_DIR}/${release_id}"
+    local staging="${DEPLOY_RELEASES_DIR}/.${release_id}.staging.$$"
     local extract_container="${SERVICE_NAME}-extract-$$"
-    local current_target=""
-    local target_real=""
 
-    current_target=$(readlink -f "${DEPLOY_CURRENT_LINK}" 2>/dev/null || true)
+    log INFO "Pulling image: ${DOCKER_IMAGE}"
+    docker pull "${DOCKER_IMAGE}" 2>&1 | tee -a "${LOG_FILE}"
+    verify_pulled_image_architecture
+
     if [[ -d "${target}" ]]; then
-        target_real=$(readlink -f "${target}" 2>/dev/null || true)
-    fi
-
-    if [[ -n "${current_target}" ]] && [[ -n "${target_real}" ]] && [[ "${current_target}" == "${target_real}" ]]; then
-        local current_image=""
+        local staged_image=""
         if [[ -f "${target}/.deploy/meta.json" ]]; then
-            current_image=$(sed -n 's/.*"image": "\([^"]*\)".*/\1/p' "${target}/.deploy/meta.json" | head -1)
+            staged_image=$(sed -n 's/.*"image": "\([^"]*\)".*/\1/p' "${target}/.deploy/meta.json" | head -1)
         fi
-        if [[ "${current_image}" == "${DOCKER_IMAGE}" ]]; then
+        if [[ "${staged_image}" == "${DOCKER_IMAGE}" ]]; then
             RELEASE_DIR="${target}"
-            log WARN "Image release ${RELEASE_SHA} is already active with the same digest — reusing existing static files"
+            log WARN "Image release ${release_id} already exists with the same digest — reusing existing static files"
             return 0
         fi
-        log ERROR "Active release ${RELEASE_SHA} already exists with a different image digest"
-        log ERROR "Current: ${current_image:-unknown}"
+        log ERROR "Image release identity ${release_id} already exists with inconsistent metadata"
+        log ERROR "Current: ${staged_image:-unknown}"
         log ERROR "Requested: ${DOCKER_IMAGE}"
-        log ERROR "Refusing to replace the live same-SHA release in place; deploy a new SHA or drain/remove the old release manually."
+        log ERROR "Refusing to replace an immutable image release directory in place."
         exit 1
     fi
 
     rm -rf "${staging}"
     mkdir -p "${staging}/.next"
-    if [[ -d "${target}" ]]; then
-        log WARN "Release ${RELEASE_SHA} already on disk but is not active — replacing after staging succeeds"
-    fi
-
-    log INFO "Pulling image: ${DOCKER_IMAGE}"
-    docker pull "${DOCKER_IMAGE}" 2>&1 | tee -a "${LOG_FILE}"
-    verify_pulled_image_architecture
 
     docker rm -f "${extract_container}" >/dev/null 2>&1 || true
     # shellcheck disable=SC2064
@@ -1377,8 +1395,8 @@ META
     chmod o+x "${DEPLOY_ROOT}" "${DEPLOY_RELEASES_DIR}" "${staging}" 2>/dev/null || true
     chmod -R o+rX "${staging}/.next/static" "${staging}/public" 2>/dev/null || true
 
-    rm -rf "${target}"
     mv "${staging}" "${target}"
+    NEW_RELEASE_DIR="${target}"
 
     local file_count
     file_count=$(find "${target}" -type f | wc -l)
@@ -1912,9 +1930,13 @@ activate_nginx_config() {
 #===============================================================================
 
 atomic_symlink_swap() {
-    log STEP "Atomic symlink swap → ${RELEASE_SHA}..."
+    if [[ -z "${RELEASE_ID}" ]]; then
+        log ERROR "Cannot activate release: RELEASE_ID is empty"
+        exit 1
+    fi
+    log STEP "Atomic symlink swap → ${RELEASE_ID}..."
 
-    local target="${DEPLOY_RELEASES_DIR}/${RELEASE_SHA}"
+    local target="${DEPLOY_RELEASES_DIR}/${RELEASE_ID}"
     local tmp="${DEPLOY_CURRENT_LINK}.tmp.$$"
 
     # Two-step for atomic replace on ext4/xfs via rename(2):
@@ -2061,8 +2083,8 @@ trim_old_releases() {
     # We never touch the release that `current` points to.
     local current_target
     current_target=$(readlink "${DEPLOY_CURRENT_LINK}" 2>/dev/null || true)
-    local current_sha=""
-    [[ -n "${current_target}" ]] && current_sha="$(basename "${current_target}")"
+    local current_release_id=""
+    [[ -n "${current_target}" ]] && current_release_id="$(basename "${current_target}")"
 
     mapfile -t releases < <(
         find "${DEPLOY_RELEASES_DIR}" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %f\n' \
@@ -2071,7 +2093,7 @@ trim_old_releases() {
 
     local kept=0
     for rel in "${releases[@]}"; do
-        if [[ "${rel}" == "${current_sha}" ]] || [[ ${kept} -lt ${RELEASE_RETENTION_COUNT} ]]; then
+        if [[ "${rel}" == "${current_release_id}" ]] || [[ ${kept} -lt ${RELEASE_RETENTION_COUNT} ]]; then
             kept=$((kept + 1))
             continue
         fi
@@ -2287,7 +2309,7 @@ image_deploy() {
 # ROLLBACK MODE — restore a retained image/artifact release
 #===============================================================================
 
-current_release_sha() {
+current_release_id() {
     if [[ ! -L "${DEPLOY_CURRENT_LINK}" ]]; then
         return 0
     fi
@@ -2298,7 +2320,7 @@ current_release_sha() {
 }
 
 resolve_rollback_release() {
-    local current_sha="$1"
+    local current_release_id="$1"
 
     if [[ -n "${ROLLBACK_TARGET_SHA}" ]]; then
         local matches=()
@@ -2327,7 +2349,7 @@ resolve_rollback_release() {
 
     local candidate
     for candidate in "${candidates[@]}"; do
-        if [[ -n "${candidate}" ]] && [[ "${candidate}" != "${current_sha}" ]]; then
+        if [[ -n "${candidate}" ]] && [[ "${candidate}" != "${current_release_id}" ]]; then
             echo "${candidate}"
             return 0
         fi
@@ -2359,23 +2381,23 @@ rollback_deploy() {
     validate_env_file
     validate_staging_env_contract
 
-    local current_sha
-    current_sha="$(current_release_sha)"
-    if [[ -z "${current_sha}" ]]; then
+    local current_release_id
+    current_release_id="$(current_release_id)"
+    if [[ -z "${current_release_id}" ]]; then
         log ERROR "No active release symlink found at ${DEPLOY_CURRENT_LINK}"
         exit 1
     fi
 
-    local target_sha
-    target_sha="$(resolve_rollback_release "${current_sha}")"
-    if [[ "${target_sha}" == "${current_sha}" ]]; then
-        log ERROR "Rollback target is already active: ${target_sha}"
+    local target_release_id
+    target_release_id="$(resolve_rollback_release "${current_release_id}")"
+    if [[ "${target_release_id}" == "${current_release_id}" ]]; then
+        log ERROR "Rollback target is already active: ${target_release_id}"
         exit 1
     fi
 
-    RELEASE_SHA="${target_sha}"
-    RELEASE_DIR="${DEPLOY_RELEASES_DIR}/${RELEASE_SHA}"
-    ROLLBACK_PREV_SHA="${current_sha}"
+    RELEASE_ID="${target_release_id}"
+    RELEASE_DIR="${DEPLOY_RELEASES_DIR}/${RELEASE_ID}"
+    ROLLBACK_PREV_SHA="${current_release_id}"
 
     [[ -d "${RELEASE_DIR}" ]] || {
         log ERROR "Rollback release directory missing: ${RELEASE_DIR}"
@@ -2386,7 +2408,13 @@ rollback_deploy() {
         exit 1
     }
 
-    log INFO "Rollback target: ${current_sha} -> ${RELEASE_SHA}"
+    RELEASE_SHA="$(release_meta_value "${RELEASE_DIR}" sha)"
+    if [[ -z "${RELEASE_SHA}" ]]; then
+        log ERROR "Rollback release metadata is missing source SHA: ${RELEASE_DIR}/.deploy/meta.json"
+        exit 1
+    fi
+
+    log INFO "Rollback target: ${current_release_id} -> ${RELEASE_ID} (source sha=${RELEASE_SHA})"
 
     local target_image
     target_image="$(release_meta_value "${RELEASE_DIR}" image)"
@@ -2396,7 +2424,7 @@ rollback_deploy() {
             exit 1
         fi
         if ! command -v docker &>/dev/null; then
-            log ERROR "Docker is required to roll back image release ${RELEASE_SHA}"
+            log ERROR "Docker is required to roll back image release ${RELEASE_ID}"
             exit 1
         fi
         if ! docker info &>/dev/null; then


### PR DESCRIPTION
## Summary
- key image releases by source SHA plus immutable digest prefix
- keep rollback source SHA separate from release directory identity
- remove failed newly staged releases after restoration
- verify production SHA through deploy metadata

## Validation
- npm test: 704 passed
- npm run typecheck
- npm run lint
- Bash syntax check
- deployment workflow YAML parse