### PR TITLE
Retry private TTS health across nginx reload

### DIFF
--- a/portfolio/lib/__tests__/ttsDeploymentTopology.contract.test.ts
+++ b/portfolio/lib/__tests__/ttsDeploymentTopology.contract.test.ts
@@ -70,6 +70,8 @@ describe('centralized Pocket TTS deployment topology', () => {
   it('checks synthesis through public HTTPS nginx only after reload', () => {
     expect(deployScript).toContain('--resolve "${DOMAIN}:443:127.0.0.1"');
     expect(deployScript).toContain('"https://${DOMAIN}/api/tts"');
+    expect(deployScript).toContain('for attempt in {1..10}; do');
+    expect(deployScript).toContain('Private Pocket TTS gateway status check failed after ${attempt} attempts');
     expect(deployScript).toMatch(
       /image_deploy\(\) \{[^]*if ! reload_nginx[^]*private_tts_gateway_health_check[^]*tts_health_check[^]*rollback_deploy\(\)/,
     );

--- a/portfolio/scripts/deploy.sh
+++ b/portfolio/scripts/deploy.sh
@@ -2011,14 +2011,25 @@ private_tts_gateway_health_check() {
     local response_file
     response_file=$(mktemp "/tmp/${SERVICE_NAME}-tts-private-health.XXXXXX")
     local http_code="000"
-    http_code=$(curl -sS -o "${response_file}" -w "%{http_code}" --max-time 10 \
-        --interface 127.0.0.1 \
-        -H "X-Portfolio-TTS-Token: ${TTS_BACKEND_TOKEN}" \
-        -H "Origin: https://${DOMAIN}" \
-        "http://${TTS_PRIVATE_LISTEN}/api/tts" 2>>"${LOG_FILE}" || echo "000")
-    if [[ "${http_code}" != "200" ]] || ! grep -q '"ok":true' "${response_file}"; then
+    local status_ready=false
+    local attempt
+    for attempt in {1..10}; do
+        http_code=$(curl -sS -o "${response_file}" -w "%{http_code}" --max-time 10 \
+            --interface 127.0.0.1 \
+            -H "X-Portfolio-TTS-Token: ${TTS_BACKEND_TOKEN}" \
+            -H "Origin: https://${DOMAIN}" \
+            "http://${TTS_PRIVATE_LISTEN}/api/tts" 2>>"${LOG_FILE}" || echo "000")
+        if [[ "${http_code}" == "200" ]] && grep -q '"ok":true' "${response_file}"; then
+            status_ready=true
+            break
+        fi
+        if (( attempt < 10 )); then
+            sleep 1
+        fi
+    done
+    if [[ "${status_ready}" != "true" ]]; then
         rm -f "${response_file}"
-        log ERROR "Private Pocket TTS gateway status check failed (HTTP ${http_code})"
+        log ERROR "Private Pocket TTS gateway status check failed after ${attempt} attempts (HTTP ${http_code})"
         return 1
     fi
 


### PR DESCRIPTION
## Summary
- retry authenticated private gateway status during nginx graceful worker handoff
- fail only after ten bounded attempts
- keep synthesis verification after the authenticated status path is ready

## Validation
- npm test: 704 passed
- npm run typecheck
- npm run lint
- Bash syntax check
- workflow YAML parse