### PR TITLE
Initialize production remote TTS precheck domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -706,6 +706,7 @@ jobs:
 
             SHA="${{ github.sha }}"
             SITE="${{ inputs.site || 'portfolio' }}"
+            DOMAIN="${{ env.DOMAIN }}"
             TTS_MODE="${{ matrix.server.tts_mode }}"
             DEPLOY_MODE="${{ env.DEPLOY_MODE }}"
             TARBALL="/tmp/portfolio-${SHA}.tar.gz"

--- a/portfolio/lib/__tests__/ttsDeploymentTopology.contract.test.ts
+++ b/portfolio/lib/__tests__/ttsDeploymentTopology.contract.test.ts
@@ -133,5 +133,7 @@ describe('centralized Pocket TTS deployment topology', () => {
       );
       expect(workflow).toContain('max-parallel: 1');
     }
+    expect(productionWorkflow).toContain('DOMAIN="${{ env.DOMAIN }}"');
+    expect(productionWorkflow).toContain('-H "Origin: https://${DOMAIN}"');
   });
 });


### PR DESCRIPTION
## Summary
- initialize DOMAIN in the production deploy shell before remote TTS reachability checks
- cover the Origin header contract in the deployment topology test

## Validation
- npm test: 704 passed
- npm run typecheck
- npm run lint
- production workflow YAML parse