### PR TITLE
fix(deploy): restore public asset layout

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -159,6 +159,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          rm -rf .next/standalone/public
           cp -r .next/static .next/standalone/.next/
           cp -r public        .next/standalone/
 
@@ -864,6 +865,23 @@ jobs:
             fi
             echo "Verified $ASSET_COUNT local nginx static assets for $SVC_NAME"
 
+            for resource_spec in \
+              "/resources/aboutPhoto.webp:image/webp" \
+              "/resources/audioAgent.mp4:video/mp4" \
+              "/resources/resume.pdf:application/pdf"; do
+              resource_path="${resource_spec%%:*}"
+              expected_mime="${resource_spec#*:}"
+              headers_file="$(mktemp)"
+              resource_code="$(curl -sk -r 0-0 -D "$headers_file" -o /dev/null -w "%{http_code}" --max-time 10 \
+                --resolve "${SVC_DOMAIN}:443:127.0.0.1" "https://${SVC_DOMAIN}${resource_path}" 2>/dev/null || echo "000")"
+              if [ "$resource_code" != "206" ] || ! grep -qiE "^content-type:[[:space:]]*${expected_mime}([;[:space:]]|$)" "$headers_file"; then
+                rm -f "$headers_file"
+                fail "Public resource failed through local nginx: ${resource_path} (HTTP ${resource_code}, expected 206 ${expected_mime})"
+              fi
+              rm -f "$headers_file"
+            done
+            echo "Verified ranged public resources through local nginx"
+
             if [ "${{ env.DEPLOY_MODE }}" = "image" ]; then
               if ! sudo docker ps --format '{{.Names}}' | grep -qx "$SVC_NAME"; then
                 echo "Docker container is not running: $SVC_NAME"
@@ -961,6 +979,23 @@ jobs:
               echo "::error::One or more staging static assets returned non-200"
               exit 1
             fi
+
+            for resource_spec in \
+              "/resources/aboutPhoto.webp:image/webp" \
+              "/resources/audioAgent.mp4:video/mp4" \
+              "/resources/resume.pdf:application/pdf"; do
+              resource_path="${resource_spec%%:*}"
+              expected_mime="${resource_spec#*:}"
+              resource_headers="$(mktemp)"
+              resource_status="$(curl -sS -r 0-0 -D "$resource_headers" -o /dev/null -w "%{http_code}" --max-time 10 \
+                -H "Cache-Control: no-cache" "https://${{ env.STAGING_DOMAIN }}${resource_path}" 2>/dev/null || echo "000")"
+              if [ "$resource_status" != "206" ] || ! grep -qiE "^content-type:[[:space:]]*${expected_mime}([;[:space:]]|$)" "$resource_headers"; then
+                rm -f "$resource_headers"
+                echo "::error::Staging public resource failed through Cloudflare: ${resource_path} (HTTP ${resource_status}, expected 206 ${expected_mime})"
+                exit 1
+              fi
+              rm -f "$resource_headers"
+            done
           fi
 
           chat_headers_file="$(mktemp)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,6 +215,7 @@ jobs:
 
           # Next.js standalone omits static/ and public/ — copy them in
           cp -r .next/static .next/standalone/.next/
+          rm -rf .next/standalone/public
           cp -r public        .next/standalone/
 
           # Ship deploy.sh + nginx template INSIDE the artifact at .deploy/
@@ -1066,6 +1067,23 @@ jobs:
             fi
             echo "Verified $ASSET_COUNT local nginx static assets for $SVC_NAME"
 
+            for resource_spec in \
+              "/resources/aboutPhoto.webp:image/webp" \
+              "/resources/audioAgent.mp4:video/mp4" \
+              "/resources/resume.pdf:application/pdf"; do
+              resource_path="${resource_spec%%:*}"
+              expected_mime="${resource_spec#*:}"
+              headers_file="$(mktemp)"
+              resource_code="$(curl -sk -r 0-0 -D "$headers_file" -o /dev/null -w "%{http_code}" --max-time 10 \
+                --resolve "${SVC_DOMAIN}:443:127.0.0.1" "https://${SVC_DOMAIN}${resource_path}" 2>/dev/null || echo "000")"
+              if [ "$resource_code" != "206" ] || ! grep -qiE "^content-type:[[:space:]]*${expected_mime}([;[:space:]]|$)" "$headers_file"; then
+                rm -f "$headers_file"
+                fail "Public resource failed through local nginx: ${resource_path} (HTTP ${resource_code}, expected 206 ${expected_mime})"
+              fi
+              rm -f "$headers_file"
+            done
+            echo "Verified ranged public resources through local nginx"
+
             # Log the directory identity; deploy metadata below is authoritative
             # for the source Git SHA because image release IDs include a digest.
             sudo test -L "$DEPLOY_ROOT/current" || fail "missing current symlink: $DEPLOY_ROOT/current"
@@ -1132,3 +1150,41 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Rollback (if the automatic rollback didn't fire):**" >> $GITHUB_STEP_SUMMARY
           echo "Re-run the workflow on the last known-good SHA — the deploy script will flip the symlink back to that release dir if it's still on disk." >> $GITHUB_STEP_SUMMARY
+
+  smoke-production:
+    name: Smoke production resources through Cloudflare
+    needs: deploy-production
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Verify public resources at the edge
+        run: |
+          set -euo pipefail
+
+          for resource_spec in \
+            "/resources/aboutPhoto.webp:image/webp" \
+            "/resources/audioAgent.mp4:video/mp4" \
+            "/resources/resume.pdf:application/pdf"; do
+            resource_path="${resource_spec%%:*}"
+            expected_mime="${resource_spec#*:}"
+            headers_file="$(mktemp)"
+            trap 'rm -f "$headers_file"' EXIT
+
+            resource_status="$(curl -sS -r 0-0 -D "$headers_file" -o /dev/null -w "%{http_code}" \
+              --retry 3 --retry-delay 2 --max-time 15 \
+              -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125 Safari/537.36" \
+              "https://${{ env.DOMAIN }}${resource_path}" 2>/dev/null || echo "000")"
+
+            echo "${resource_path}: HTTP ${resource_status}"
+            grep -Ei '^(content-type:|content-range:|cache-control:|cf-cache-status:|cf-ray:|server:)' "$headers_file" || true
+
+            if [ "$resource_status" != "206" ] \
+              || ! grep -qiE "^content-type:[[:space:]]*${expected_mime}([;[:space:]]|$)" "$headers_file"; then
+              echo "::error::Production public resource failed through Cloudflare: ${resource_path} (HTTP ${resource_status}, expected 206 ${expected_mime})"
+              exit 1
+            fi
+
+            rm -f "$headers_file"
+            trap - EXIT
+          done

--- a/portfolio/Dockerfile
+++ b/portfolio/Dockerfile
@@ -45,7 +45,13 @@ RUN mkdir -p /app/standalone/.next /app/standalone/.deploy \
     && cp -r .next/standalone/. /app/standalone/ \
     && rm -rf /app/standalone/.next/static \
     && cp -r .next/static /app/standalone/.next/ \
+    && rm -rf /app/standalone/public \
     && cp -r public /app/standalone/public \
+    && find /app/standalone/.next/static -type f -print -quit | grep -q . \
+    && test -s /app/standalone/public/resources/aboutPhoto.webp \
+    && test -s /app/standalone/public/resources/audioAgent.mp4 \
+    && test -s /app/standalone/public/resources/resume.pdf \
+    && test ! -e /app/standalone/public/public \
     && cp scripts/deploy.sh /app/standalone/.deploy/deploy.sh \
     && cp scripts/machine.conf.example /app/standalone/.deploy/machine.conf.example \
     && cp scripts/portfolio.conf.example /app/standalone/.deploy/portfolio.conf.example \

--- a/portfolio/scripts/deploy.sh
+++ b/portfolio/scripts/deploy.sh
@@ -1269,6 +1269,34 @@ record_previous_release() {
     fi
 }
 
+validate_static_release_layout() {
+    local release_dir="$1"
+    local required_file
+
+    if [[ ! -d "${release_dir}/.next/static" ]] \
+        || ! find "${release_dir}/.next/static" -type f -print -quit | grep -q .; then
+        log ERROR "Release static layout is invalid: .next/static is missing or empty (${release_dir})"
+        return 1
+    fi
+
+    if [[ -e "${release_dir}/public/public" ]]; then
+        log ERROR "Release static layout is invalid: nested public/public directory detected (${release_dir})"
+        return 1
+    fi
+
+    for required_file in \
+        public/resources/aboutPhoto.webp \
+        public/resources/audioAgent.mp4 \
+        public/resources/resume.pdf; do
+        if [[ ! -s "${release_dir}/${required_file}" ]]; then
+            log ERROR "Release static layout is invalid: missing or empty ${required_file} (${release_dir})"
+            return 1
+        fi
+    done
+
+    log SUCCESS "Release static layout validated: ${release_dir}"
+}
+
 stage_release() {
     RELEASE_ID="${RELEASE_SHA}"
     log STEP "Staging release ${RELEASE_SHA}..."
@@ -1288,6 +1316,7 @@ stage_release() {
             log ERROR "Refusing artifact same-SHA reuse; the active release is likely an image-mode static release. Deploy a new SHA or drain/remove it manually."
             exit 1
         fi
+        validate_static_release_layout "${target}" || exit 1
         log WARN "Release ${RELEASE_SHA} is already active — reusing existing staged files"
         return 0
     fi
@@ -1295,6 +1324,7 @@ stage_release() {
     local staging="${DEPLOY_RELEASES_DIR}/.${RELEASE_SHA}.staging.$$"
     rm -rf "${staging}"
     mkdir -p "${staging}"
+    NEW_RELEASE_DIR="${staging}"
 
     if [[ -d "${target}" ]]; then
         log WARN "Release ${RELEASE_SHA} already on disk but is not active — replacing after staging succeeds"
@@ -1308,6 +1338,7 @@ stage_release() {
     # Copy the production .env.local into the release (systemd reads it from here)
     cp "${DEPLOY_ENV_FILE}" "${staging}/.env.local"
     chmod 600 "${staging}/.env.local"
+    validate_static_release_layout "${staging}" || exit 1
 
     # Fix ownership: service user owns the bundle
     chown -R "${SERVICE_USER}:${SERVICE_USER}" "${staging}"
@@ -1353,6 +1384,7 @@ stage_image_release() {
             staged_image=$(sed -n 's/.*"image": "\([^"]*\)".*/\1/p' "${target}/.deploy/meta.json" | head -1)
         fi
         if [[ "${staged_image}" == "${DOCKER_IMAGE}" ]]; then
+            validate_static_release_layout "${target}" || exit 1
             RELEASE_DIR="${target}"
             log WARN "Image release ${release_id} already exists with the same digest — reusing existing static files"
             return 0
@@ -1366,6 +1398,7 @@ stage_image_release() {
 
     rm -rf "${staging}"
     mkdir -p "${staging}/.next"
+    NEW_RELEASE_DIR="${staging}"
 
     docker rm -f "${extract_container}" >/dev/null 2>&1 || true
     # shellcheck disable=SC2064
@@ -1379,6 +1412,8 @@ stage_image_release() {
         || { log ERROR "Could not extract public/ from image"; exit 1; }
     docker cp "${extract_container}:/app/.deploy" "${staging}/" \
         || { log ERROR "Could not extract .deploy/ from image"; exit 1; }
+
+    validate_static_release_layout "${staging}" || exit 1
 
     docker rm -f "${extract_container}" >/dev/null 2>&1 || true
     trap - RETURN
@@ -2441,6 +2476,7 @@ rollback_deploy() {
         log ERROR "Rollback release is missing nginx template: ${RELEASE_DIR}/.deploy/${NGINX_CONF_TEMPLATE}"
         exit 1
     }
+    validate_static_release_layout "${RELEASE_DIR}" || exit 1
 
     RELEASE_SHA="$(release_meta_value "${RELEASE_DIR}" sha)"
     if [[ -z "${RELEASE_SHA}" ]]; then
@@ -2750,6 +2786,7 @@ legacy_deploy() {
     install_dependencies
     build_project
     prepare_legacy_standalone
+    validate_static_release_layout "${LEGACY_STANDALONE_DIR}" || exit 1
     cleanup_git_changes
     ensure_legacy_systemd
 
@@ -2826,6 +2863,41 @@ health_check() {
         log DEBUG "✓ Chat API: ${chat_code}"; passed=$((passed + 1))
     else
         log ERROR "✗ Chat API: ${chat_code}"
+    fi
+
+    local resource_check
+    local resource_path
+    local expected_type
+    local resource_headers
+    local resource_code
+    local resource_type
+    # Atomic release modes can restore the previous symlink if a public asset
+    # fails through nginx. Legacy mode mutates its standalone directory in
+    # place, so it is guarded by validate_static_release_layout before restart.
+    if [[ "${MODE}" != "legacy" ]]; then
+        for resource_check in \
+            "/resources/aboutPhoto.webp|image/webp" \
+            "/resources/audioAgent.mp4|video/mp4" \
+            "/resources/resume.pdf|application/pdf"; do
+            resource_path="${resource_check%%|*}"
+            expected_type="${resource_check##*|}"
+            total=$((total + 1))
+
+            resource_headers=$(mktemp "/tmp/${SERVICE_NAME}-resource-health.XXXXXX")
+            resource_code=$(curl -sk -D "${resource_headers}" -o /dev/null -w "%{http_code}" \
+                --max-time 10 -H "Range: bytes=0-0" \
+                --resolve "${DOMAIN}:443:127.0.0.1" \
+                "https://${DOMAIN}${resource_path}" 2>/dev/null || echo "000")
+            resource_type=$(awk -F': *' 'tolower($1) == "content-type" { value=tolower($2); sub(/\r$/, "", value); print value; exit }' "${resource_headers}")
+            rm -f "${resource_headers}"
+
+            if [[ "${resource_code}" == "206" ]] && [[ "${resource_type}" == "${expected_type}"* ]]; then
+                log DEBUG "✓ Resource ${resource_path}: ${resource_code} ${resource_type}"
+                passed=$((passed + 1))
+            else
+                log ERROR "✗ Resource ${resource_path}: HTTP ${resource_code}, Content-Type ${resource_type:-missing}"
+            fi
+        done
     fi
 
     if [[ ${passed} -eq ${total} ]]; then


### PR DESCRIPTION
## Root cause

Commit `e05e72f` added `public/sounds/voice/TTSReference.mp3` to Next.js output file tracing. That made `.next/standalone/public` exist before Docker packaging. The Dockerfile then ran `cp -r public /app/standalone/public`, which nested the source tree at `/app/public/public`.

Nginx serves `/resources/*` from the host release's `public/resources`, so images, videos, and the resume PDF returned origin 404s. The same files remained reachable at the unintended `/public/resources/*` path. Cloudflare correctly bypassed caching for the no-store 404 responses; it did not cause the incident.

## Fix

- Replace the traced standalone `public` directory before copying the complete source tree.
- Assert critical image, video, and PDF files exist at the expected image paths and reject `public/public`.
- Validate extracted and reused releases before activation, including rollback targets.
- Probe representative resources through local Nginx during deploy verification.
- Probe staging and production resources through Cloudflare after deployment.

## Validation

- `SKIP_EMBEDDINGS_BUILD=1 npm run build`
- `npm run lint`
- `npm run typecheck`
- `vitest run` (708 passed)
- Git Bash `bash -n portfolio/scripts/deploy.sh`
- Parsed both edited workflow files as YAML
- Asserted fresh standalone output contains required resources and no nested `public/public`
- `git diff --check`