### PR TITLE
fix(deploy): require awk in all modes

### DIFF
--- a/portfolio/scripts/deploy.sh
+++ b/portfolio/scripts/deploy.sh
@@ -600,13 +600,11 @@ check_root() {
 
 check_dependencies() {
     log STEP "Checking dependencies..."
-    local deps=("nginx" "systemctl" "curl" "sed" "flock")
+    local deps=("nginx" "systemctl" "curl" "sed" "awk" "flock")
     if [[ "${MODE}" == "legacy" ]]; then
         deps+=("git" "node" "npm" "nice" "ionice")
     elif [[ "${MODE}" == "image" ]]; then
-        deps+=("docker" "awk")
-    elif [[ "${MODE}" == "rollback" ]]; then
-        deps+=("awk")
+        deps+=("docker")
     fi
 
     local missing=()


### PR DESCRIPTION
## Why

Copilot correctly noted that `health_check()` uses `awk` for `Content-Type` parsing while artifact mode did not declare `awk` during dependency preflight.

The issue is broader than that one line: shared memory, disk, environment, release, and health code paths also use `awk`. Replacing the parser with `grep | head | sed` would merely trade one undeclared dependency for two others.

## Fix

Declare `awk` once in the shared dependency list and remove the redundant image/rollback additions. Every mode now fails early and clearly on a minimal host without `awk`.

## Validation

- Git Bash `bash -n portfolio/scripts/deploy.sh`
- `git diff --check`
- VS Code diagnostics: no errors