### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/portfolio/lib/__tests__/releasePipeline.contract.test.ts
+++ b/portfolio/lib/__tests__/releasePipeline.contract.test.ts
@@ -27,18 +27,15 @@ const dockerfile = fs.readFileSync(path.join(projectRoot, 'Dockerfile'), 'utf8')
 const deployScript = fs.readFileSync(path.join(projectRoot, 'scripts', 'deploy.sh'), 'utf8');
 
 describe('release version promotion', () => {
-  it('uses package.json as the 0.2.0 baseline mirrored by the npm lockfile', () => {
-    expect(packageJson.version).toBe('0.2.0');
+  it('uses a semantic package.json version mirrored by the npm lockfile', () => {
+    expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+$/);
     expect(packageLock.version).toBe(packageJson.version);
     expect(
       (packageLock.packages as Record<string, { version?: string }> | undefined)?.['']?.version,
     ).toBe(packageJson.version);
   });
 
-  it('makes the next genuinely new staging release 0.3.0', () => {
-    const [major, minor] = String(packageJson.version).split('.').map(Number);
-
-    expect(`${major}.${minor + 1}.0`).toBe('0.3.0');
+  it('increments the minor version for each genuinely new staging release', () => {
     expect(stagingPromotion).toContain(
       'npm@${{ env.CI_NPM_VERSION }} --prefix portfolio version minor',
     );

--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "clsx": "^2.1.1",

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "npm@10.9.8",
   "engines": {


### PR DESCRIPTION
Creates the v0.3.0 staging release metadata and makes the release contract version-agnostic so future minor bumps remain testable.