### PR TITLE
fix(ci): promote staging releases through reviewed PRs

### DIFF
--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -1,16 +1,29 @@
-name: Promote dev/lkg to Staging
+name: Prepare or Promote a Staging Release
 
 permissions:
   actions: write
   contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Prepare a release PR or promote an approved release"
+        required: true
+        default: prepare-release
+        type: choice
+        options:
+          - prepare-release
+          - promote-release
       source_branch:
-        description: "Source branch to promote"
+        description: "Source branch for prepare-release"
         required: false
         default: dev/lkg
+        type: string
+      release_sha:
+        description: "Exact merged dev/lkg release SHA for promote-release"
+        required: false
         type: string
 
 concurrency:
@@ -23,8 +36,9 @@ env:
   CI_NPM_VERSION: "10.9.8"
 
 jobs:
-  promote:
-    name: Move deployed/staging
+  prepare-release:
+    if: ${{ inputs.mode == 'prepare-release' }}
+    name: Prepare staging release PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -40,93 +54,206 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Create and promote minor release
-        id: promote
+      - name: Prepare release branch and pull request
+        id: prepare
         env:
+          GH_TOKEN: ${{ github.token }}
           SOURCE_BRANCH: ${{ inputs.source_branch || 'dev/lkg' }}
           TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
         run: |
           set -euo pipefail
 
           if [ "$SOURCE_BRANCH" != "dev/lkg" ]; then
-            echo "::error::Only dev/lkg can be promoted to deployed/staging by this workflow. Got: $SOURCE_BRANCH"
+            echo "::error::Only dev/lkg can prepare a deployed/staging release. Got: $SOURCE_BRANCH"
             exit 1
           fi
 
-          git fetch origin "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" || true
+          git fetch origin "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}"
           git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" || true
-
-          if ! git rev-parse --verify --quiet "origin/${SOURCE_BRANCH}" >/dev/null; then
-            echo "::error::Source branch does not exist on origin: ${SOURCE_BRANCH}"
-            exit 1
-          fi
 
           source_sha="$(git rev-parse "origin/${SOURCE_BRANCH}")"
           target_sha=""
           if git rev-parse --verify --quiet "origin/${TARGET_BRANCH}" >/dev/null; then
             target_sha="$(git rev-parse "origin/${TARGET_BRANCH}")"
-            if [ "$source_sha" = "$target_sha" ]; then
-              version="$(git show "${source_sha}:portfolio/package.json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(data).version));")"
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-              echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-              echo "release_sha=$source_sha" >> "$GITHUB_OUTPUT"
-              echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
-              echo "version=$version" >> "$GITHUB_OUTPUT"
-              echo "deployed/staging already points at ${source_sha}."
-              exit 0
-            fi
             if ! git merge-base --is-ancestor "$target_sha" "$source_sha"; then
-              echo "::error::Refusing non-fast-forward promotion. Merge deployed/staging back into dev/lkg or use a reviewed manual recovery."
+              echo "::error::Refusing non-fast-forward release preparation. Merge deployed/staging back into dev/lkg or use a reviewed manual recovery."
               echo "Current ${TARGET_BRANCH}: ${target_sha}"
               echo "Requested ${SOURCE_BRANCH}: ${source_sha}"
               exit 1
             fi
           fi
 
-          git checkout --detach "$source_sha"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          previous_version="$(git show "${source_sha}:portfolio/package.json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(data).version));")"
+          next_version="$(node -e 'const version = process.argv[1]; const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version); if (!match) process.exit(1); process.stdout.write(`${match[1]}.${Number(match[2]) + 1}.0`);' "$previous_version")"
+          release_branch="release/staging-v${next_version}"
 
-          previous_version="$(node -p "require('./portfolio/package.json').version")"
-          npx -y npm@${{ env.CI_NPM_VERSION }} --prefix portfolio version minor --no-git-tag-version --ignore-scripts
-          version="$(node -p "require('./portfolio/package.json').version")"
-          if [ "$version" = "$previous_version" ]; then
-            echo "::error::Minor version bump did not change portfolio/package.json"
+          git fetch origin "+refs/heads/${release_branch}:refs/remotes/origin/${release_branch}" || true
+
+          changed=false
+          if git rev-parse --verify --quiet "origin/${release_branch}" >/dev/null; then
+            release_sha="$(git rev-parse "origin/${release_branch}")"
+            release_parent="$(git rev-parse "${release_sha}^")"
+            release_version="$(git show "${release_sha}:portfolio/package.json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(data).version));")"
+
+            if [ "$release_parent" != "$source_sha" ] || [ "$release_version" != "$next_version" ]; then
+              echo "::error::Existing ${release_branch} does not match the current dev/lkg release candidate. Refusing to overwrite it."
+              exit 1
+            fi
+          else
+            git checkout --detach "$source_sha"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            npx -y npm@${{ env.CI_NPM_VERSION }} --prefix portfolio version minor --no-git-tag-version --ignore-scripts
+            version="$(node -p "require('./portfolio/package.json').version")"
+            if [ "$version" != "$next_version" ]; then
+              echo "::error::Minor version bump produced ${version}; expected ${next_version}."
+              exit 1
+            fi
+
+            git add portfolio/package.json portfolio/package-lock.json
+            changed_files="$(git diff --cached --name-only)"
+            if [ "$changed_files" != $'portfolio/package-lock.json\nportfolio/package.json' ]; then
+              echo "::error::Release preparation changed files outside portfolio/package.json and portfolio/package-lock.json."
+              git diff --cached --name-only
+              exit 1
+            fi
+
+            git commit -m "chore(release): v${version}"
+            release_sha="$(git rev-parse HEAD)"
+            git push origin "HEAD:refs/heads/${release_branch}"
+            changed=true
+          fi
+
+          pr_json="$(gh pr list --head "$release_branch" --base "$SOURCE_BRANCH" --state all --json number,state,url --limit 1)"
+          pr_details="$(printf '%s' "$pr_json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => { const pr = JSON.parse(data)[0]; process.stdout.write(pr ? [pr.number, pr.state, pr.url].join(' ') : ''); });")"
+          pr_number=""
+          pr_state=""
+          pr_url=""
+          if [ -n "$pr_details" ]; then
+            read -r pr_number pr_state pr_url <<< "$pr_details"
+          fi
+
+          if [ -n "${pr_number:-}" ]; then
+            if [ "$pr_state" != "OPEN" ]; then
+              echo "::error::Existing release PR #${pr_number} is ${pr_state}; refusing to create another PR from ${release_branch}."
+              exit 1
+            fi
+          else
+            pr_url="$(gh pr create --base "$SOURCE_BRANCH" --head "$release_branch" --title "chore(release): v${next_version}" --body "Prepared staging release v${next_version}. Merge this reviewed PR before running promote-release.")"
+            pr_number="${pr_url##*/}"
+          fi
+
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$release_branch" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "version=$next_version" >> "$GITHUB_OUTPUT"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Release preparation summary
+        run: |
+          echo "## Staging release preparation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Source | \`${{ inputs.source_branch || 'dev/lkg' }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Release branch | \`${{ steps.prepare.outputs.release_branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Release SHA | \`${{ steps.prepare.outputs.release_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`${{ steps.prepare.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Pull request | [#${{ steps.prepare.outputs.pr_number }}](${{ steps.prepare.outputs.pr_url }}) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch created | \`${{ steps.prepare.outputs.changed }}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+  promote-release:
+    if: ${{ inputs.mode == 'promote-release' }}
+    name: Promote approved staging release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Promote approved release to staging
+        id: promote
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          SOURCE_BRANCH: dev/lkg
+          TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_SHA:-}" ]; then
+            echo "::error::release_sha is required when mode is promote-release."
             exit 1
           fi
 
-          git add portfolio/package.json portfolio/package-lock.json
-          git commit -m "chore(release): v${version}"
-          release_sha="$(git rev-parse HEAD)"
+          git fetch origin "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}"
+          git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" || true
 
-          git push --atomic origin \
-            "HEAD:refs/heads/${SOURCE_BRANCH}" \
-            "HEAD:refs/heads/${TARGET_BRANCH}"
+          source_sha="$(git rev-parse "origin/${SOURCE_BRANCH}")"
+          if [ "$RELEASE_SHA" != "$source_sha" ]; then
+            echo "::error::release_sha must exactly match origin/${SOURCE_BRANCH} HEAD."
+            echo "Expected: ${source_sha}"
+            echo "Received: ${RELEASE_SHA}"
+            exit 1
+          fi
 
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
-          echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          version="$(git show "${RELEASE_SHA}:portfolio/package.json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(data).version));")"
+          release_subject="$(git log -1 --format=%s "$RELEASE_SHA")"
+          if [ "$release_subject" != "chore(release): v${version}" ]; then
+            echo "::error::release_sha must be the merged release commit for portfolio/package.json version ${version}."
+            echo "Expected subject: chore(release): v${version}"
+            echo "Received subject: ${release_subject}"
+            exit 1
+          fi
+
+          target_sha=""
+          if git rev-parse --verify --quiet "origin/${TARGET_BRANCH}" >/dev/null; then
+            target_sha="$(git rev-parse "origin/${TARGET_BRANCH}")"
+            if [ "$target_sha" != "$RELEASE_SHA" ] && ! git merge-base --is-ancestor "$target_sha" "$RELEASE_SHA"; then
+              echo "::error::Refusing non-fast-forward promotion. Merge deployed/staging back into dev/lkg or use a reviewed manual recovery."
+              echo "Current ${TARGET_BRANCH}: ${target_sha}"
+              echo "Requested release: ${RELEASE_SHA}"
+              exit 1
+            fi
+          fi
+
+          changed=false
+          if [ "$target_sha" != "$RELEASE_SHA" ]; then
+            git push origin "${RELEASE_SHA}:refs/heads/${TARGET_BRANCH}"
+            changed=true
+          fi
+
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch staging deploy workflow
         env:
           GH_TOKEN: ${{ github.token }}
-          TARGET_BRANCH: ${{ steps.promote.outputs.target_branch }}
+          TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
         run: |
           set -euo pipefail
           gh workflow run deploy-staging.yml --ref "$TARGET_BRANCH"
 
       - name: Promotion summary
         run: |
-          echo "## Staging promotion" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Staging release promotion" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Source | \`${{ inputs.source_branch || 'dev/lkg' }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Target | \`${{ env.TARGET_BRANCH }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Source SHA | \`${{ steps.promote.outputs.source_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Release SHA | \`${{ steps.promote.outputs.release_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Version | \`${{ steps.promote.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Changed | \`${{ steps.promote.outputs.changed }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Target advanced | \`${{ steps.promote.outputs.changed }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Deploy workflow | \`deploy-staging.yml\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,8 @@ Production delivery is branch-promoted and container-based. The workflow files a
 dev/lkg -> deployed/staging -> deployed/production
 ```
 
-- The staging promotion workflow accepts only `dev/lkg`, creates a minor package release when the SHA is new, atomically advances `dev/lkg` and `deployed/staging`, then dispatches staging deployment.
+- Staging uses two manual dispatches. First run `promote-staging.yml` with `prepare-release`: it accepts only `dev/lkg`, verifies `deployed/staging` is an ancestor, creates `release/staging-v<version>` with the minor package bump, and opens or reports its PR into `dev/lkg`.
+- After the required PR review and merge, run `promote-staging.yml` with `promote-release` and the exact merged `dev/lkg` release SHA. It verifies the release commit, fast-forwards only `deployed/staging`, then dispatches staging deployment.
 - The production promotion workflow fast-forwards `deployed/production` from `deployed/staging` after a GitHub production-environment approval, then dispatches production deployment.
 - Production deployment has a separate production-environment approval before it mutates hosts.
 

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -44,7 +44,7 @@ Copy [.env.example](.env.example) for local setup. Provider keys, signing secret
 ## Delivery
 
 - [Dockerfile](Dockerfile) builds the multi-architecture image with the standalone app and Pocket TTS runtime.
-- `dev/lkg` promotes to `deployed/staging`; production fast-forwards the approved staged release to `deployed/production`.
+- `prepare-release` creates a reviewed minor-version PR into `dev/lkg`; after it merges, `promote-release` fast-forwards that exact release SHA to `deployed/staging`. Production fast-forwards the approved staged release to `deployed/production`.
 - Staging serves `staging.whoisdhruv.com` as `portfolio-staging` on port `3010`; production serves `whoisdhruv.com` as `portfolio`.
 
 ## Focused Guides

--- a/portfolio/lib/__tests__/releasePipeline.contract.test.ts
+++ b/portfolio/lib/__tests__/releasePipeline.contract.test.ts
@@ -38,7 +38,12 @@ describe('release version promotion', () => {
     ).toBe(packageJson.version);
   });
 
-  it('increments the minor version for each genuinely new staging release', () => {
+  it('prepares each staging release as a minor-version pull request', () => {
+    expect(stagingPromotion).toContain('mode:');
+    expect(stagingPromotion).toContain('default: prepare-release');
+    expect(stagingPromotion).toContain('- prepare-release');
+    expect(stagingPromotion).toContain('- promote-release');
+    expect(stagingPromotion).toContain('pull-requests: write');
     expect(stagingPromotion).toContain(
       'npm@${{ env.CI_NPM_VERSION }} --prefix portfolio version minor',
     );
@@ -48,16 +53,37 @@ describe('release version promotion', () => {
     expect(stagingPromotion).toContain('git commit -m "chore(release): v${version}"');
   });
 
-  it('bumps only after detecting a real source delta and advances both branches atomically', () => {
-    const noChangeGuard = stagingPromotion.indexOf('if [ "$source_sha" = "$target_sha" ]');
-    const bump = stagingPromotion.indexOf('version minor --no-git-tag-version');
+  it('creates an idempotent reviewed release branch without pushing dev/lkg', () => {
+    const prepareRelease = stagingPromotion.slice(
+      stagingPromotion.indexOf('  prepare-release:'),
+      stagingPromotion.indexOf('  promote-release:'),
+    );
 
-    expect(noChangeGuard).toBeGreaterThan(-1);
-    expect(bump).toBeGreaterThan(noChangeGuard);
-    expect(stagingPromotion).toContain('git push --atomic origin');
-    expect(stagingPromotion).toContain('"HEAD:refs/heads/${SOURCE_BRANCH}"');
-    expect(stagingPromotion).toContain('"HEAD:refs/heads/${TARGET_BRANCH}"');
-    expect(stagingPromotion).toContain('gh workflow run deploy-staging.yml --ref "$TARGET_BRANCH"');
+    expect(prepareRelease).toContain('if [ "$SOURCE_BRANCH" != "dev/lkg" ]');
+    expect(prepareRelease).toContain('git merge-base --is-ancestor "$target_sha" "$source_sha"');
+    expect(prepareRelease).toContain('release_branch="release/staging-v${next_version}"');
+    expect(prepareRelease).toContain('git push origin "HEAD:refs/heads/${release_branch}"');
+    expect(prepareRelease).toContain('gh pr list --head "$release_branch" --base "$SOURCE_BRANCH"');
+    expect(prepareRelease).toContain('gh pr create --base "$SOURCE_BRANCH" --head "$release_branch"');
+    expect(prepareRelease).toContain('GH_TOKEN: ${{ github.token }}');
+    expect(stagingPromotion).not.toContain('git push --atomic origin');
+    expect(stagingPromotion).not.toContain('"HEAD:refs/heads/${SOURCE_BRANCH}"');
+  });
+
+  it('promotes only an exact approved release head to deployed/staging and dispatches staging', () => {
+    const promoteRelease = stagingPromotion.slice(stagingPromotion.indexOf('  promote-release:'));
+
+    expect(promoteRelease).toContain('if [ -z "${RELEASE_SHA:-}" ]');
+    expect(promoteRelease).toContain('if [ "$RELEASE_SHA" != "$source_sha" ]');
+    expect(promoteRelease).toContain('if [ "$release_subject" != "chore(release): v${version}" ]');
+    expect(promoteRelease).toContain(
+      'git push origin "${RELEASE_SHA}:refs/heads/${TARGET_BRANCH}"',
+    );
+    expect(promoteRelease).not.toContain('version minor');
+    expect(promoteRelease).not.toContain('npm version');
+    expect(promoteRelease).not.toContain('refs/heads/${SOURCE_BRANCH}"');
+    expect(promoteRelease).toContain('gh workflow run deploy-staging.yml --ref "$TARGET_BRANCH"');
+    expect(promoteRelease).toContain('GH_TOKEN: ${{ github.token }}');
   });
 
   it('promotes the exact staged release to production without another version bump', () => {


### PR DESCRIPTION
## Summary

Fixes the failed staging promotion from [run 31318241405](https://github.com/Dhruv-Mishra/portfolioWebsite/actions/runs/31318241405), where the old workflow tried to push a generated version commit directly to protected `dev/lkg` and was rejected by the PR rule.

`promote-staging.yml` now has two explicit dispatch modes:

1. `prepare-release` creates or reuses `release/staging-v<version>`, bumps only the package version and lockfile, and opens a PR into `dev/lkg`.
2. `promote-release` requires the exact merged release SHA, verifies its release subject/version, fast-forwards only `deployed/staging`, and dispatches staging deployment.

This retains the required review barrier and does not require a ruleset bypass credential.

## Validation

- `rtk vitest run lib/__tests__/releasePipeline.contract.test.ts` — 10 passed
- Parsed `.github/workflows/promote-staging.yml`
- `rtk git diff --check`