### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -3,7 +3,6 @@ name: Prepare or Promote a Staging Release
 permissions:
   actions: write
   contents: write
-  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -54,10 +53,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Prepare release branch and pull request
+      - name: Prepare release branch
         id: prepare
         env:
-          GH_TOKEN: ${{ github.token }}
           SOURCE_BRANCH: ${{ inputs.source_branch || 'dev/lkg' }}
           TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
         run: |
@@ -125,30 +123,12 @@ jobs:
             changed=true
           fi
 
-          pr_json="$(gh pr list --head "$release_branch" --base "$SOURCE_BRANCH" --state all --json number,state,url --limit 1)"
-          pr_details="$(printf '%s' "$pr_json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => { const pr = JSON.parse(data)[0]; process.stdout.write(pr ? [pr.number, pr.state, pr.url].join(' ') : ''); });")"
-          pr_number=""
-          pr_state=""
-          pr_url=""
-          if [ -n "$pr_details" ]; then
-            read -r pr_number pr_state pr_url <<< "$pr_details"
-          fi
-
-          if [ -n "${pr_number:-}" ]; then
-            if [ "$pr_state" != "OPEN" ]; then
-              echo "::error::Existing release PR #${pr_number} is ${pr_state}; refusing to create another PR from ${release_branch}."
-              exit 1
-            fi
-          else
-            pr_url="$(gh pr create --base "$SOURCE_BRANCH" --head "$release_branch" --title "chore(release): v${next_version}" --body "Prepared staging release v${next_version}. Merge this reviewed PR before running promote-release.")"
-            pr_number="${pr_url##*/}"
-          fi
+          compare_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${SOURCE_BRANCH}...${release_branch}"
 
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
           echo "release_branch=$release_branch" >> "$GITHUB_OUTPUT"
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "compare_url=$compare_url" >> "$GITHUB_OUTPUT"
           echo "version=$next_version" >> "$GITHUB_OUTPUT"
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
@@ -162,7 +142,7 @@ jobs:
           echo "| Release branch | \`${{ steps.prepare.outputs.release_branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Release SHA | \`${{ steps.prepare.outputs.release_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Version | \`${{ steps.prepare.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Pull request | [#${{ steps.prepare.outputs.pr_number }}](${{ steps.prepare.outputs.pr_url }}) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Open release PR | [Open release PR](${{ steps.prepare.outputs.compare_url }}) |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Branch created | \`${{ steps.prepare.outputs.changed }}\` |" >> "$GITHUB_STEP_SUMMARY"
 
   promote-release:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,8 +8,8 @@ Production delivery is branch-promoted and container-based. The workflow files a
 dev/lkg -> deployed/staging -> deployed/production
 ```
 
-- Staging uses two manual dispatches. First run `promote-staging.yml` with `prepare-release`: it accepts only `dev/lkg`, verifies `deployed/staging` is an ancestor, creates `release/staging-v<version>` with the minor package bump, and opens or reports its PR into `dev/lkg`.
-- After the required PR review and merge, run `promote-staging.yml` with `promote-release` and the exact merged `dev/lkg` release SHA. It verifies the release commit, fast-forwards only `deployed/staging`, then dispatches staging deployment.
+- Staging uses two manual dispatches. First run `promote-staging.yml` with `prepare-release`: it accepts only `dev/lkg`, verifies `deployed/staging` is an ancestor, creates or reuses `release/staging-v<version>` with the minor package bump, and reports an **Open release PR** compare link.
+- Open that link manually in GitHub (or with an authorized client), create the release PR into `dev/lkg`, and merge it after the required review. Then run `promote-staging.yml` with `promote-release` and the exact merged `dev/lkg` release SHA. It verifies the release commit, fast-forwards only `deployed/staging`, then dispatches staging deployment.
 - The production promotion workflow fast-forwards `deployed/production` from `deployed/staging` after a GitHub production-environment approval, then dispatches production deployment.
 - Production deployment has a separate production-environment approval before it mutates hosts.
 

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -44,7 +44,7 @@ Copy [.env.example](.env.example) for local setup. Provider keys, signing secret
 ## Delivery
 
 - [Dockerfile](Dockerfile) builds the multi-architecture image with the standalone app and Pocket TTS runtime.
-- `prepare-release` creates a reviewed minor-version PR into `dev/lkg`; after it merges, `promote-release` fast-forwards that exact release SHA to `deployed/staging`. Production fast-forwards the approved staged release to `deployed/production`.
+- `prepare-release` creates or reuses a minor-version release branch and reports an **Open release PR** compare link. Open and merge that PR into `dev/lkg` manually (or with an authorized client), then run `promote-release` to fast-forward that exact release SHA to `deployed/staging`. Production fast-forwards the approved staged release to `deployed/production`.
 - Staging serves `staging.whoisdhruv.com` as `portfolio-staging` on port `3010`; production serves `whoisdhruv.com` as `portfolio`.
 
 ## Focused Guides

--- a/portfolio/lib/__tests__/releasePipeline.contract.test.ts
+++ b/portfolio/lib/__tests__/releasePipeline.contract.test.ts
@@ -38,12 +38,12 @@ describe('release version promotion', () => {
     ).toBe(packageJson.version);
   });
 
-  it('prepares each staging release as a minor-version pull request', () => {
+  it('prepares each staging release as a minor-version release branch', () => {
     expect(stagingPromotion).toContain('mode:');
     expect(stagingPromotion).toContain('default: prepare-release');
     expect(stagingPromotion).toContain('- prepare-release');
     expect(stagingPromotion).toContain('- promote-release');
-    expect(stagingPromotion).toContain('pull-requests: write');
+    expect(stagingPromotion).not.toContain('pull-requests: write');
     expect(stagingPromotion).toContain(
       'npm@${{ env.CI_NPM_VERSION }} --prefix portfolio version minor',
     );
@@ -63,9 +63,19 @@ describe('release version promotion', () => {
     expect(prepareRelease).toContain('git merge-base --is-ancestor "$target_sha" "$source_sha"');
     expect(prepareRelease).toContain('release_branch="release/staging-v${next_version}"');
     expect(prepareRelease).toContain('git push origin "HEAD:refs/heads/${release_branch}"');
-    expect(prepareRelease).toContain('gh pr list --head "$release_branch" --base "$SOURCE_BRANCH"');
-    expect(prepareRelease).toContain('gh pr create --base "$SOURCE_BRANCH" --head "$release_branch"');
-    expect(prepareRelease).toContain('GH_TOKEN: ${{ github.token }}');
+    expect(prepareRelease).toContain(
+      'compare_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${SOURCE_BRANCH}...${release_branch}"',
+    );
+    expect(prepareRelease).toContain('echo "compare_url=$compare_url" >> "$GITHUB_OUTPUT"');
+    expect(prepareRelease).not.toContain('gh pr list');
+    expect(prepareRelease).not.toContain('gh pr create');
+    expect(prepareRelease).not.toContain('GH_TOKEN:');
+    expect(prepareRelease).not.toContain('pr_number=');
+    expect(prepareRelease).not.toContain('pr_url=');
+    expect(stagingPromotion).toContain(
+      '| Open release PR | [Open release PR](${{ steps.prepare.outputs.compare_url }}) |',
+    );
+    expect(stagingPromotion).not.toContain('steps.prepare.outputs.pr_number');
     expect(stagingPromotion).not.toContain('git push --atomic origin');
     expect(stagingPromotion).not.toContain('"HEAD:refs/heads/${SOURCE_BRANCH}"');
   });

--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "clsx": "^2.1.1",

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "packageManager": "npm@10.9.8",
   "engines": {


### PR DESCRIPTION
## Staging Release

Prepares the reviewed `v0.8.0` release for staging.

- Bumps only `portfolio/package.json` and `portfolio/package-lock.json` to `0.8.0`.
- Includes the final promotion-workflow correction: `prepare-release` now creates/reuses a release branch and supplies a manual PR link, because this repository disallows `GITHUB_TOKEN`-created PRs.
- After this PR merges, run `promote-staging.yml` with `mode=promote-release` and the resulting merge SHA. That workflow verifies the exact release subject/version, fast-forwards only `deployed/staging`, and dispatches staging deployment.

Validation: `rtk vitest run lib/__tests__/releasePipeline.contract.test.ts`, YAML parsing, and `git diff --check`.