### PR TITLE
fix(ci): make staging model audit advisory

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -895,9 +895,9 @@ jobs:
           if ! curl -fsS --max-time 15 -H "Accept: application/json" \
             -o "$MODEL_STATUS_FILE" "$MODEL_STATUS_URL"; then
             echo "## Staging model canary audit" >> "$GITHUB_STEP_SUMMARY"
-            echo "Core model-status route failed: \`$MODEL_STATUS_URL\`." >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::Staging model-status route failed: $MODEL_STATUS_URL"
-            exit 1
+            echo "Model probes skipped because the core model-status route was unavailable: \`$MODEL_STATUS_URL\`." >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Staging model-status route failed: $MODEL_STATUS_URL"
+            exit 0
           fi
 
           if ! jq -e '
@@ -905,9 +905,9 @@ jobs:
             (.deploymentCanaryModelIds | all(.[]; type == "string" and length > 0 and test("^[^\\r\\n]+$")))
           ' "$MODEL_STATUS_FILE" >/dev/null; then
             echo "## Staging model canary audit" >> "$GITHUB_STEP_SUMMARY"
-            echo "Core model-status response did not provide a valid \`deploymentCanaryModelIds\` array." >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::Staging model-status response schema is invalid"
-            exit 1
+            echo "Model probes skipped because \`deploymentCanaryModelIds\` was missing or invalid." >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Staging model-status response schema is invalid"
+            exit 0
           fi
 
           mapfile -t DEPLOYMENT_CANARY_MODEL_IDS < <(jq -r '.deploymentCanaryModelIds[]' "$MODEL_STATUS_FILE")

--- a/portfolio/lib/__tests__/releasePipeline.contract.test.ts
+++ b/portfolio/lib/__tests__/releasePipeline.contract.test.ts
@@ -208,8 +208,20 @@ describe('release version promotion', () => {
     expect(stagingCanaryJob).toContain('deploymentCanaryModelIds');
     expect(stagingCanaryJob).toContain('mapfile -t DEPLOYMENT_CANARY_MODEL_IDS');
     expect(stagingCanaryJob).toContain('for CHAT_MODEL in "${DEPLOYMENT_CANARY_MODEL_IDS[@]}"; do');
-    expect(stagingCanaryJob).toContain('::error::Staging model-status route failed');
-    expect(stagingCanaryJob).toContain('::error::Staging model-status response schema is invalid');
+    expect(stagingCanaryJob).toContain(
+      'Model probes skipped because the core model-status route was unavailable:',
+    );
+    expect(stagingCanaryJob).toContain(
+      'Model probes skipped because \\`deploymentCanaryModelIds\\` was missing or invalid.',
+    );
+    expect(stagingCanaryJob).toMatch(
+      /echo "::warning::Staging model-status route failed: \$MODEL_STATUS_URL"\n\s+exit 0/,
+    );
+    expect(stagingCanaryJob).toMatch(
+      /echo "::warning::Staging model-status response schema is invalid"\n\s+exit 0/,
+    );
+    expect(stagingCanaryJob).not.toContain('::error::Staging model-status route failed');
+    expect(stagingCanaryJob).not.toContain('::error::Staging model-status response schema is invalid');
     expect(stagingCanaryJob).toContain('::warning::Staging chat canary degraded:');
     expect(stagingCanaryJob).toContain('## Staging model canary audit');
     expect(stagingCanaryJob).toContain('jq -nc --arg model "$CHAT_MODEL"');


### PR DESCRIPTION
## Summary

Makes the staging model audit fully advisory.

The failed staging run `31318732770` was blocked before model probes began because `/api/chat/model-status` returned HTTP 403. This change:

- warns and skips probes when the catalog endpoint is unavailable;
- warns and skips probes when `deploymentCanaryModelIds` is malformed;
- keeps individual model-response degradation as warnings;
- leaves deployment, VM, TTS, asset, and metadata verification blocking.

## Validation

- `rtk vitest run lib/__tests__/releasePipeline.contract.test.ts` (10 passed)
- workflow YAML parse
- `git diff --check`