### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "clsx": "^2.1.1",

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "packageManager": "npm@10.9.8",
   "engines": {


### PR DESCRIPTION
## Staging Release

Prepares `v0.9.0` for staging with the merged advisory model-audit change.

- Bumps `portfolio/package.json` and `portfolio/package-lock.json` from `0.8.0` to `0.9.0`.
- Includes the merged `fix(ci): make staging model audit advisory` change.
- Model catalog access/schema and individual model responses are advisory during deployment; deployment, VM, TTS, asset, and metadata checks remain blocking.

After approval and merge, `promote-staging.yml` can run in `promote-release` mode using the resulting merge SHA.